### PR TITLE
Fix: File System Event Race Condition (fixes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ pytest tests/integration/ -v   # Integration tests only
 ```
 
 ### Test Coverage
-- **577+ tests** passing with **83% code coverage**
-- **Real-time monitoring** validated with mock journal events
+- **580 tests** passing with **83% code coverage**
+- **Real-time monitoring** validated with mock journal events and race condition fixes
 - **Event processing** tested with 213 event types across 17 categories
 - **Comprehensive event coverage** with 98% categorization accuracy (Milestone 17)
 - **Historical data search** with 61 tests covering date parsing, natural language queries, and range filtering (Milestone 18)
@@ -121,6 +121,7 @@ pytest tests/integration/ -v   # Integration tests only
 - **MCP server** tested with comprehensive unit and integration tests
 - **MCP tools, resources, and prompts** extensively tested with edge cases
 - **Dynamic Theme System** tested with 159 comprehensive tests covering performance, edge cases, and integration scenarios
+- **File monitoring race conditions** tested and fixed (Issue #12)
 
 ### Documentation
 - **[Testing Guide](docs/TESTING_GUIDE.md)** - Comprehensive testing instructions


### PR DESCRIPTION
## Summary

Fixes #12 - Resolves race condition where new journal events were not ingested in real-time when Claude Desktop (FastMCP) was running.

## Root Cause Analysis

**The Problem:**
Elite Dangerous writes to journal files, but the OS may buffer writes before flushing to disk. The file system watcher (watchdog) can fire modification events BEFORE the OS flushes the write, causing the file size to appear unchanged.

**The Bug:**
In `src/journal/parser.py`, the `read_journal_file_incremental()` method checked file size before attempting to read:

```python
current_size = file_path.stat().st_size
if current_size <= last_position:
    return [], last_position  # Early return - data discarded!
```

**Impact:**
- Users reported that new events didn't appear in Claude Desktop
- Required restarting Claude Desktop to see latest gameplay events
- No fallback mechanism to recover missed events

## Solution

**Remove the file size check entirely:**
- Always attempt to read from `last_position`
- If no new data exists, `read()` returns empty string (cheap operation)
- Eliminates race condition without performance penalty
- Maintains all existing functionality

**Why This Works:**
- `open()` and `seek()` are cheap operations
- Reading from current position is safe even if no new data
- No risk of missing data due to timing issues
- Windows file sharing modes already handle concurrent access correctly

## Changes Made

### Code Changes
- **src/journal/parser.py**: Removed size check (lines 270-272)
- Added detailed comment explaining the race condition and fix
- Maintains all existing error handling and position tracking

### Tests Added
Added 3 comprehensive tests in `tests/unit/test_journal_parser.py`:

1. **test_issue_12_file_size_check_race_condition** - Simulates the exact race condition scenario
2. **test_issue_12_no_events_missed_on_rapid_writes** - Validates rapid sequential writes (10ms apart)
3. **test_issue_12_incremental_read_without_size_check** - Verifies fix behavior and edge cases

All tests include:
- GitHub issue link in comments
- Detailed docstrings explaining the problem
- Clear assertions with error messages

### Documentation Updates
- **README.md**: Updated test count from 577+ to 580
- Added note about race condition fixes

## Testing

**New Tests Added:**
- `test_issue_12_file_size_check_race_condition()` - Race condition simulation
- `test_issue_12_no_events_missed_on_rapid_writes()` - Rapid write handling
- `test_issue_12_incremental_read_without_size_check()` - Fix verification

**Test Results:**
- ✅ All 580 tests passing
- ✅ No regressions in existing test suite
- ✅ Code coverage maintained at 83%

**Full Test Suite Results:**
```
tests/unit/test_journal_parser.py: 36 passed
tests/unit/test_journal_monitor.py: 40 passed
tests/unit/test_events.py: 30 passed
... (all test suites passing)
Total: 580 passed
Coverage: 83%
```

## Investigation Evidence

The issue reporter conducted thorough investigation:
- ✅ File locking is NOT the issue (verified with concurrent read/write tests)
- ⚠️ Windows `ReadDirectoryChangesW` API can coalesce rapid modifications
- ⚠️ Event timing analysis showed 10ms gaps between events
- **PRIMARY ISSUE**: File write buffer race condition identified

See full investigation in issue #12 for detailed analysis and test scripts.

## Reproduction Steps (Before Fix)

1. Start Elite Dangerous
2. Start Claude Desktop with MCP server
3. Perform rapid in-game actions (multiple jumps, scans)
4. Ask Claude Desktop about recent activity
5. **Observe:** Missing or delayed events
6. Restart Claude Desktop
7. **Observe:** Events now appear

**After Fix:** Events appear immediately without restart required.

## Additional Considerations

### Windows API Limitations
- ReadDirectoryChangesW buffer can overflow
- Events may be coalesced or lost
- No guarantee of event delivery
- This fix handles the primary race condition

### Future Enhancements (Optional)
Consider adding polling fallback (Solution 2 from issue #12) for:
- Guaranteed recovery from missed watchdog events
- Handling Windows API buffer overflow scenarios
- Maximum delay guarantee (poll interval)

## Commits

1. `test: add tests for issue #12 race condition` - Added failing/documenting tests
2. `fix: resolve file monitoring race condition (fixes #12)` - Implemented fix
3. `docs: update test counts for issue #12 fix` - Updated documentation

Fixes #12